### PR TITLE
Fix homepage styling

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -5,6 +5,5 @@
  */
 
 module.exports = {
-  plugins: [`gatsby-plugin-styled-components`],
-  plugins: [`gatsby-plugin-react-helmet`]
+  plugins: [`gatsby-plugin-styled-components`, `gatsby-plugin-react-helmet`]
 }

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -35,7 +35,7 @@ export default function Home(props) {
 
   return (
     <PageContainerDiv>
-      <Helmet route={createRouteString(location.pathname)}  />
+      <Helmet route={createRouteString(location.pathname)}/>
       <NavWrapper />
       <HomePageHeaderContainer>
         <HomePageHeader>

--- a/src/styles/baseStyles.js
+++ b/src/styles/baseStyles.js
@@ -59,7 +59,7 @@ const inputStyles = css`
   border-radius: 5px;
   font-size: 16px;
   padding: 4px 8px;
-  width: 280px;
+  width: 400px;
 `
 
 const inputLabelStyles = css`
@@ -74,7 +74,7 @@ const baseTextInputStyles = css`
 
 const inputContainerStyles = css`
   ${baseTextInputStyles};
-  width: 300px;
+  width: 400px;
   margin: 10px 0;
 `
 
@@ -84,7 +84,7 @@ const textAreaStyles = css`
   font-size: 16px;
   resize: none;
   padding: 4px 9px;
-  width: 280px;
+  width: 400px;
   height: 100px;
 `
 


### PR DESCRIPTION
- Seems like the homepage styling issue was due to a regression that was a result of adding an overwriting `plugin: []` line in the gatsby config. Fixed, let's hope this actually fixes the next build!